### PR TITLE
Add simple Flask REST API for students

### DIFF
--- a/my-python-project/README.md
+++ b/my-python-project/README.md
@@ -1,19 +1,35 @@
 # My Python Project
 
-This is a simple Python project that demonstrates a basic "Hello, World!" program.
+This project includes simple scripts and a REST API for managing student details.
 
 ## Purpose
 
-The purpose of this project is to provide a minimal example of a Python application that outputs "Hello, World!" to the console.
+Originally this repository contained a "Hello, World!" example. It has now been
+extended with a small API built using Flask that stores student information in
+`students.json`.
 
-## How to Run
+## How to Run the API
 
-1. Ensure you have Python installed on your machine.
-2. Navigate to the project directory.
-3. Run the main program using the following command:
+1. Install the requirements:
 
+   ```bash
+   pip install -r requirements.txt
    ```
-   python src/main.py
+
+2. Start the Flask application:
+
+   ```bash
+   python src/api.py
    ```
 
-This will print "Hello, World!" to the console.
+   The server will start on `http://127.0.0.1:5000` by default.
+
+## API Endpoints
+
+- `GET /students` – return the list of stored students.
+- `GET /students/<id>` – return the student at the given index.
+- `POST /students` – add a new student. Send a JSON body containing
+  `first_name`, `last_name`, `grade`, `age`, `phone_number`, `email`, `address`,
+  `father_name` and `mother_name`.
+
+All student data is persisted in the `students.json` file at the project root.

--- a/my-python-project/requirements.txt
+++ b/my-python-project/requirements.txt
@@ -1,1 +1,1 @@
-# This file is intentionally left blank.
+Flask

--- a/my-python-project/src/api.py
+++ b/my-python-project/src/api.py
@@ -1,0 +1,56 @@
+from flask import Flask, jsonify, request, abort
+import json
+from pathlib import Path
+
+app = Flask(__name__)
+
+DATA_FILE = Path(__file__).resolve().parent.parent / 'students.json'
+
+def load_students():
+    if DATA_FILE.exists():
+        try:
+            with open(DATA_FILE, 'r') as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return []
+    return []
+
+
+def save_students(students):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(students, f, indent=4)
+
+
+@app.route('/students', methods=['GET'])
+def get_students():
+    students = load_students()
+    return jsonify(students)
+
+
+@app.route('/students/<int:student_id>', methods=['GET'])
+def get_student(student_id):
+    students = load_students()
+    if 0 <= student_id < len(students):
+        return jsonify(students[student_id])
+    abort(404)
+
+
+@app.route('/students', methods=['POST'])
+def add_student():
+    if not request.json:
+        abort(400)
+    student = request.json
+    required_fields = [
+        'first_name', 'last_name', 'grade', 'age', 'phone_number',
+        'email', 'address', 'father_name', 'mother_name'
+    ]
+    if not all(field in student for field in required_fields):
+        abort(400)
+    students = load_students()
+    students.append(student)
+    save_students(students)
+    return jsonify(student), 201
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a Flask-based REST API under `src/api.py`
- document API usage in README
- specify Flask dependency

## Testing
- `python -m py_compile src/api.py`


------
https://chatgpt.com/codex/tasks/task_e_68609b7d38788332a2341f0bceab4161