### PR TITLE
Add MongoDB backed FastAPI

### DIFF
--- a/student_api/README.md
+++ b/student_api/README.md
@@ -1,24 +1,27 @@
 # Student API
 
-This project provides a simple REST API for managing student details using [FastAPI](https://fastapi.tiangolo.com/). It stores data in-memory and is intended for demonstration purposes.
+This project provides a simple REST API for managing student details using [FastAPI](https://fastapi.tiangolo.com/). Data can be stored in MongoDB or kept in-memory for testing.
 
 ## Requirements
 
 - Python 3.8+
 - FastAPI
 - Uvicorn
+- Motor (MongoDB driver)
+- Jinja2
 
 All required packages are listed in `requirements.txt`.
 
 ## Running the API
 
-Install dependencies and start the application using `uvicorn` (run the command
-from the repository root or adjust the import path accordingly):
+Install dependencies and start the application using `uvicorn`:
 
 ```bash
 pip install -r requirements.txt
 uvicorn student_api.app.main:app --reload
 ```
+
+If the environment variable `MONGODB_URI` is set, the API will store data in MongoDB. Otherwise it falls back to an in-memory store.
 
 The server will start at `http://127.0.0.1:8000`. Interactive API docs are available at `http://127.0.0.1:8000/docs`.
 
@@ -47,8 +50,6 @@ Example JSON body:
 }
 ```
 
-This workflow allows you to test all endpoints from Postman without writing any code.
-
 ## Available Endpoints
 
 - `POST /students` – Create a new student
@@ -64,4 +65,3 @@ Tests use `pytest`. Execute them with:
 ```bash
 pytest
 ```
-

--- a/student_api/app/models.py
+++ b/student_api/app/models.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, EmailStr, Field, validator
+import re
+
+phone_regex = re.compile(r"^\d{10}$")
+
+class StudentBase(BaseModel):
+    first_name: str = Field(..., example="John")
+    last_name: str = Field(..., example="Doe")
+    grade: str = Field(..., example="10")
+    age: int = Field(..., ge=1, example=15)
+    phone_number: str = Field(..., example="1234567890")
+    email: EmailStr = Field(..., example="john@example.com")
+    address: str = Field(..., example="123 Main St")
+    father_name: str = Field(..., example="Father Name")
+    mother_name: str = Field(..., example="Mother Name")
+
+    @validator("phone_number")
+    def validate_phone(cls, v: str) -> str:
+        if not phone_regex.match(v):
+            raise ValueError("phone number must be 10 digits")
+        return v
+
+class StudentCreate(StudentBase):
+    pass
+
+class Student(StudentBase):
+    id: str

--- a/student_api/app/repository.py
+++ b/student_api/app/repository.py
@@ -1,0 +1,102 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from .models import StudentCreate, Student
+
+class StudentRepository(ABC):
+    @abstractmethod
+    async def create(self, student: StudentCreate) -> Student:
+        pass
+
+    @abstractmethod
+    async def list(self) -> List[Student]:
+        pass
+
+    @abstractmethod
+    async def get(self, student_id: str) -> Optional[Student]:
+        pass
+
+    @abstractmethod
+    async def update(self, student_id: str, student: StudentCreate) -> Optional[Student]:
+        pass
+
+    @abstractmethod
+    async def delete(self, student_id: str) -> bool:
+        pass
+
+class InMemoryStudentRepository(StudentRepository):
+    def __init__(self) -> None:
+        self.students = {}
+        self.current_id = 0
+
+    async def create(self, student: StudentCreate) -> Student:
+        self.current_id += 1
+        new = Student(id=str(self.current_id), **student.dict())
+        self.students[new.id] = new
+        return new
+
+    async def list(self) -> List[Student]:
+        return list(self.students.values())
+
+    async def get(self, student_id: str) -> Optional[Student]:
+        return self.students.get(student_id)
+
+    async def update(self, student_id: str, student: StudentCreate) -> Optional[Student]:
+        if student_id not in self.students:
+            return None
+        updated = Student(id=student_id, **student.dict())
+        self.students[student_id] = updated
+        return updated
+
+    async def delete(self, student_id: str) -> bool:
+        if student_id in self.students:
+            del self.students[student_id]
+            return True
+        return False
+
+try:
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from bson import ObjectId
+except Exception:  # pragma: no cover - motor not installed in tests
+    AsyncIOMotorClient = None  # type: ignore
+    ObjectId = None  # type: ignore
+
+class MongoStudentRepository(StudentRepository):
+    def __init__(self, uri: str, db_name: str = "studentdb") -> None:
+        if AsyncIOMotorClient is None:
+            raise RuntimeError("motor is required for MongoStudentRepository")
+        self.client = AsyncIOMotorClient(uri)
+        self.collection = self.client[db_name]["students"]
+
+    async def create(self, student: StudentCreate) -> Student:
+        result = await self.collection.insert_one(student.dict())
+        doc = await self.collection.find_one({"_id": result.inserted_id})
+        return Student(id=str(doc["_id"]), **{k: doc[k] for k in student.dict().keys()})
+
+    async def list(self) -> List[Student]:
+        students = []
+        async for doc in self.collection.find():
+            students.append(Student(id=str(doc["_id"]), **{k: doc[k] for k in StudentCreate.__fields__.keys()}))
+        return students
+
+    async def get(self, student_id: str) -> Optional[Student]:
+        if ObjectId is None:
+            return None
+        doc = await self.collection.find_one({"_id": ObjectId(student_id)})
+        if doc:
+            return Student(id=str(doc["_id"]), **{k: doc[k] for k in StudentCreate.__fields__.keys()})
+        return None
+
+    async def update(self, student_id: str, student: StudentCreate) -> Optional[Student]:
+        if ObjectId is None:
+            return None
+        oid = ObjectId(student_id)
+        result = await self.collection.replace_one({"_id": oid}, student.dict())
+        if result.modified_count:
+            return Student(id=student_id, **student.dict())
+        return None
+
+    async def delete(self, student_id: str) -> bool:
+        if ObjectId is None:
+            return False
+        result = await self.collection.delete_one({"_id": ObjectId(student_id)})
+        return result.deleted_count > 0

--- a/student_api/app/templates/index.html
+++ b/student_api/app/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Student API</title>
+</head>
+<body>
+    <h1>Student API</h1>
+    <p>This API allows you to manage student records.</p>
+    <p>Use a tool like Postman or the <a href="/docs">interactive docs</a> to interact with the API.</p>
+</body>
+</html>

--- a/student_api/requirements.txt
+++ b/student_api/requirements.txt
@@ -1,4 +1,6 @@
 fastapi
 uvicorn
+motor
+jinja2
 pytest
 httpx

--- a/student_api/tests/test_main.py
+++ b/student_api/tests/test_main.py
@@ -1,7 +1,10 @@
 from fastapi.testclient import TestClient
-from student_api.app.main import app
+from student_api.app.main import app, get_repository
+from student_api.app.repository import InMemoryStudentRepository
 
+app.dependency_overrides[get_repository] = lambda: InMemoryStudentRepository()
 client = TestClient(app)
+
 
 def test_create_and_get_student():
     data = {
@@ -13,7 +16,7 @@ def test_create_and_get_student():
         "email": "alice@example.com",
         "address": "123 Road",
         "father_name": "Bob",
-        "mother_name": "Carol"
+        "mother_name": "Carol",
     }
     response = client.post("/students", json=data)
     assert response.status_code == 201


### PR DESCRIPTION
## Summary
- add phone & email validation models
- support MongoDB or fallback in-memory repository
- provide simple homepage
- update tests to use repository override

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6860b8cfdb088332b736422c946af0ab